### PR TITLE
Fix: correct status order in the config selectbox

### DIFF
--- a/app/views/settings/_accept_settings.html.erb
+++ b/app/views/settings/_accept_settings.html.erb
@@ -4,7 +4,7 @@
       <th>Accept Status</th>
       <td>
 	<%= select_tag('settings[accept_status]',
-	options_for_select(IssueStatus.all, @settings['accept_status'])) %>
+	options_for_select(IssueStatus.all.sorted.map{|s| [s.name, s.name]}, @settings['accept_status'])) %>
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
Hi, a small fix to order the statuses as sorted in the administration page.
